### PR TITLE
Update pet. No overwrite of created date.

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,10 +23,11 @@ def put_pet(pet_id, pet):
     pet['id'] = pet_id
     if exists:
         logging.info('Updating pet %s..', pet_id)
+        PETS[pet_id].update(pet)
     else:
         logging.info('Creating pet %s..', pet_id)
         pet['created'] = datetime.datetime.utcnow()
-    PETS[pet_id] = pet
+        PETS[pet_id] = pet
     return NoContent, (200 if exists else 201)
 
 


### PR DESCRIPTION
The `created` field is added to the pet object only when the pet with that id is first created. Subsequent updates to that object don't include the `created` field. This fixes that bug by updating the original dict with the new values.
